### PR TITLE
Fixed a fatal error - When training, the second word was being skipped due …

### DIFF
--- a/main.py
+++ b/main.py
@@ -95,6 +95,8 @@ def train(baliky,balik,file): #načtení slovíček do .txt souboru
     WebDriverWait(driver, 10).until(
         EC.presence_of_element_located((By.ID, "word"))
     )
+
+    time.sleep(1)
     for i in range(int(driver.find_element_by_id("wordCount").text)-1):
         slovicka.append(driver.find_element_by_id("word").text)
         preklad.append(driver.find_element_by_id("translation").text)


### PR DESCRIPTION
…to poor timing (the program assumed that it can fetch the word-translation pair right away.) Tested on Firefox and Edge on multiple packs of 16 cards.
I didn't do any precise measurements so this still might not be prefect.